### PR TITLE
[Doppins] Upgrade dependency recastai to ^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "babel-polyfill": "^6.22.0",
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
-    "recastai": "^3.1.1"
+    "recastai": "^4.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
Hi!

A new version was just released of `recastai`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded recastai from `^3.1.1` to `^4.0.0`

#### Changelog:

#### Version 4.0.0
- add dialog endpoint
- add proxy parameter 
- add memory parameter

